### PR TITLE
fixes requested during avm team review

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ Default: `true`
 
 The following outputs are exported:
 
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: The name of the parent resource.
+
 ### <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints)
 
 Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints. The map value is the entire azurerm\_private\_endpoint resource.
@@ -388,6 +392,14 @@ Description: A map of private endpoints. The map key is the supplied input to va
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: This is the full output for the resource.
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The resource id for the parent resource.
+
+### <a name="output_system_assigned_mi_principal_id"></a> [system\_assigned\_mi\_principal\_id](#output\_system\_assigned\_mi\_principal\_id)
+
+Description: The system assigned managed identity principal ID of the parent resource.
 
 ## Modules
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -26,7 +26,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -20,7 +20,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/geo-replication/README.md
+++ b/examples/geo-replication/README.md
@@ -28,7 +28,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/geo-replication/main.tf
+++ b/examples/geo-replication/main.tf
@@ -20,7 +20,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/low-cost/README.md
+++ b/examples/low-cost/README.md
@@ -28,7 +28,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/low-cost/main.tf
+++ b/examples/low-cost/main.tf
@@ -20,7 +20,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/private-endpoint/README.md
+++ b/examples/private-endpoint/README.md
@@ -26,7 +26,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/examples/private-endpoint/main.tf
+++ b/examples/private-endpoint/main.tf
@@ -20,7 +20,11 @@ DESCRIPTION
 
 provider "azurerm" {
   skip_provider_registration = true
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # This ensures we have unique CAF compliant names for our resources.

--- a/locals.tf
+++ b/locals.tf
@@ -1,10 +1,5 @@
 locals {
-  resource_group_location            = try(data.azurerm_resource_group.parent[0].location, null)
-  role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
-}
-
-# Private endpoint application security group associations
-locals {
+  # Private endpoint application security group associations
   private_endpoint_application_security_group_associations = { for assoc in flatten([
     for pe_k, pe_v in var.private_endpoints : [
       for asg_k, asg_v in pe_v.application_security_group_associations : {
@@ -14,4 +9,7 @@ locals {
       }
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
+
+  resource_group_location            = try(data.azurerm_resource_group.parent[0].location, null)
+  role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.0.1"
+    "module_version": "0.1.0"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,20 @@
+# Minimum required outputs
+# https://azure.github.io/Azure-Verified-Modules/specs/shared/#id-rmfr7---category-outputs---minimum-required-outputs
+output "resource_id" {
+  description = "The resource id for the parent resource."
+  value       = azurerm_container_registry.this.id
+}
+
+output "name" {
+  description = "The name of the parent resource."
+  value       = azurerm_container_registry.this.name
+}
+
+output "system_assigned_mi_principal_id" {
+  description = "The system assigned managed identity principal ID of the parent resource."
+  value       = try(azurerm_container_registry.this.identity.principal_id, null)
+}
+
 output "private_endpoints" {
   description = "A map of private endpoints. The map key is the supplied input to var.private_endpoints. The map value is the entire azurerm_private_endpoint resource."
   value       = azurerm_private_endpoint.this

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,7 +12,7 @@ output "name" {
 
 output "system_assigned_mi_principal_id" {
   description = "The system assigned managed identity principal ID of the parent resource."
-  value       = try(azurerm_container_registry.this.identity.principal_id, null)
+  value       = try(azurerm_container_registry.this.identity[0].principal_id, null)
 }
 
 output "private_endpoints" {


### PR DESCRIPTION
to close #3 

### Review Feedback

> * terraform.lock.hcl shouldn't be in the repo per the .gitignore file.

@mbilalamjad terraform.lock.hcl was introduced to the AVM template [in this PR](https://github.com/Azure/terraform-azurerm-avm-template/pull/40), has this review finding been superseded? 

> 
> * Update the support.md file.

for @pradorodriguez please
> 
> * Consider following specs TFNFR31 for the local.tf file.

What was done was following the style of the KeyVault, which in my opinion is much more readable. However, I have merged the locals block into a single block (which I think is what your ask is).

> 
> * Consider updating version to 0.1.0 as the first version that would be published into the terraform registry per spec SNFR17.

done
> 
> * Consider updating output to contain Resource Name, ID and Object per specs RMFR7 & TFFR2.
> 
done, though I don't much care for the 'system assigned mi' output.  What if a user assigned identity is being used?  

i also note that Keyvault doesn't include the outputs in RMFR7, they seem unnecessary since you can get to them via the full resource output, but, done :)

> * Consider setting prevent_deletion_if_contains_resources to false in provider block in example code per spec TFNFR36.
> 
done

> * Consider setting a constraint on maximum major version of Provider per spec TFNFR26.

can't find any instances of this

> 
> * The Contributor and Owner teams are not added to the repo per spec SNFR20.

another one for @pradorodriguez , please.