### PR TITLE
Adding tag argument to main.telemetry.tf v2

### DIFF
--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -13,5 +13,5 @@ resource "azurerm_resource_group_template_deployment" "telemetry" {
   name                = local.telem_arm_deployment_name
   resource_group_name = var.resource_group_name
   template_content    = local.telem_arm_template_content
-  tags = {}
+  tags                = {}
 }

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -13,4 +13,5 @@ resource "azurerm_resource_group_template_deployment" "telemetry" {
   name                = local.telem_arm_deployment_name
   resource_group_name = var.resource_group_name
   template_content    = local.telem_arm_template_content
+  tags = {}
 }


### PR DESCRIPTION
Per lint recommendation:

on locals.telemetry.tf line 21:
21: telem_arm_template_content = <<TEMPLATE
22: {

Notice: tags argument is not set but supported in resource azurerm_resource_group_template_deployment (azurerm_resource_tag)

on main.telemetry.tf line 9:
9: resource "azurerm_resource_group_template_deployment" "telemetry" {

Reference: https://github.com/Azure/tflint-ruleset-azurerm-ext/blob/v0.6.0/docs/rules/azurerm_resource_tag.md