### PR TITLE
fix: correct resource name condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   description = "The name of the Container Registry."
 
   validation {
-    condition     = can(regex("^[a-z0-9]{5,50}$", var.name))
+    condition     = can(regex("^[[:alnum:]]{5,50}$", var.name))
     error_message = "The name must be between 5 and 50 characters long and can only contain lowercase letters and numbers."
   }
 }


### PR DESCRIPTION
## Description

The condition for Container Registry name is incorrect - https://github.com/Azure/terraform-azurerm-avm-res-containerregistry-registry/blob/4fb495d01b5380be083433e01003c79b05f277a5/variables.tf#L6

The correct condition as per Microsoft documentation is: "5-50 chars, Alphanumerics."

source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry

Fixes #64 
Closes #64 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ X ] Azure Verified Module updates:
  - [ X ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ X ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
