### PR TITLE
fix: resolve Standard SKU deployment failure by updating defaults for…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,10 @@ resource "azurerm_container_registry" "this" {
   network_rule_bypass_option    = var.network_rule_bypass_option
   public_network_access_enabled = var.public_network_access_enabled
   quarantine_policy_enabled     = var.quarantine_policy_enabled
-  retention_policy_in_days      = var.retention_policy_in_days
+  retention_policy_in_days      = var.sku == "Premium" ? var.retention_policy_in_days : null
   tags                          = var.tags
   trust_policy_enabled          = var.enable_trust_policy
-  zone_redundancy_enabled       = var.zone_redundancy_enabled
+  zone_redundancy_enabled       = var.sku == "Premium" ? var.zone_redundancy_enabled : false
 
   dynamic "encryption" {
     for_each = var.customer_managed_key != null ? { this = var.customer_managed_key } : {}


### PR DESCRIPTION
… zone_redundancy_enabled and retention_policy_in_days (#123)

## Description

I fixed the issue where deployments using the Standard SKU were failing by adding conditions to set appropriate default values for zone_redundancy_enabled and retention_policy_in_days only when they are supported. This ensures compatibility across different SKUs.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #123" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
