### PR TITLE
feat: fix support for versionless key id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_container_registry" "this" {
 
     content {
       identity_client_id = data.azurerm_user_assigned_identity.this[0].client_id
-      key_vault_key_id   = data.azurerm_key_vault_key.this[0].id
+      key_vault_key_id   = var.customer_managed_key.use_versionless_key ? data.azurerm_key_vault_key.this[0].versionless_id : data.azurerm_key_vault_key.this[0].id
     }
   }
   dynamic "georeplications" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "customer_managed_key" {
   type = object({
     key_vault_resource_id = string
     key_name              = string
-    key_version           = optional(string, null)
+    use_versionless_key   = optional(bool, false)
     user_assigned_identity = optional(object({
       resource_id = string
     }), null)
@@ -57,7 +57,7 @@ variable "diagnostic_settings" {
   default     = {}
   description = <<DESCRIPTION
   A map of diagnostic settings to create on the Container Registry. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-  
+
   - `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
   - `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
   - `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ A map of diagnostic settings to create on the Key Vault. The map key is delibera
 Controls the Customer managed key configuration on this resource. The following properties can be specified:
 - `key_vault_resource_id` - (Required) Resource ID of the Key Vault that the customer managed key belongs to.
 - `key_name` - (Required) Specifies the name of the Customer Managed Key Vault Key.
-- `key_version` - (Optional) The version of the Customer Managed Key Vault Key.
+- `use_versionless_key` - (Optional) Whether to use the versionless Customer Managed Key Vault Key.
 - `user_assigned_identity` - (Optional) The User Assigned Identity that has access to the key.
   - `resource_id` - (Required) The resource ID of the User Assigned Identity that has access to the key.
 DESCRIPTION


### PR DESCRIPTION
## Description

Fix support for versionless key vault key id.
There is a variable "key_version" which was never used. & it was impossible for the user to set a versionless key id.
Versionless key id is necssary when you are using auto key rotation (which is also a policy from the Microsoft Security Benchmark 2.0).

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
