### PR TITLE
fix: include version only if specified and use specified version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_container_registry" "this" {
 
     content {
       identity_client_id = data.azurerm_user_assigned_identity.this[0].client_id
-      key_vault_key_id   = data.azurerm_key_vault_key.this[0].id
+      key_vault_key_id   = format("%s%s", data.azurerm_key_vault_key.this[0].versionless_id, var.customer_managed_key.key_version != null ? "/${var.customer_managed_key.key_version}" : "")
     }
   }
   dynamic "georeplications" {

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_container_registry" "this" {
 
     content {
       identity_client_id = data.azurerm_user_assigned_identity.this[0].client_id
-      key_vault_key_id   = format("%s%s", data.azurerm_key_vault_key.this[0].versionless_id, var.customer_managed_key.key_version != null ? "/${var.customer_managed_key.key_version}" : "")
+      key_vault_key_id   = format("%s%s", data.azurerm_key_vault_key.this[0].versionless_id, encryption.value.key_version != null ? "/${encryption.value.key_version}" : "")
     }
   }
   dynamic "georeplications" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Fixes #149 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes: I'm not sure about **backwards compatible**. The change would drop the currently version centric setup with `key_version = null`.
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change: there is, see https://github.com/Azure/terraform-azurerm-avm-res-containerregistry-registry/pull/147 but it drops the key version. So the question is, either you want to be able to specify a key version and use that, or you just want to use the current version and rotate via terraform.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
