### PR TITLE
Fix: Resolve drift caused by diagnostic settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   target_resource_id             = azurerm_container_registry.this.id
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
-  log_analytics_destination_type = each.value.log_analytics_destination_type
+  log_analytics_destination_type = each.value.log_analytics_destination_type == "Dedicated" ? null : each.value.log_analytics_destination_type
   log_analytics_workspace_id     = each.value.workspace_resource_id
   partner_solution_id            = each.value.marketplace_partner_resource_id
   storage_account_id             = each.value.storage_account_resource_id


### PR DESCRIPTION
## Description
**Problem**
When diagnostic settings are configured with log_analytics_destination_type = "Dedicated" (the default value), Terraform detects configuration drift on every subsequent apply, attempting to add log_analytics_destination_type = "Dedicated" even though the setting hasn't changed.

This occurs because Azure stores the "Dedicated" destination type as null in the backend (since "Dedicated" is the default behavior), causing Terraform to detect a difference between the configuration and actual state.

**Solution**
This PR applies the same fix previously implemented in the [operational insights workspace module](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Fixes #146 

**Changes:**

- Modified log_analytics_destination_type in [main.tf:113](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use a ternary operator that converts "Dedicated" to null:

```
log_analytics_destination_type = each.value.log_analytics_destination_type == "Dedicated" ? null : each.value.log_analytics_destination_type
```

**User Impact:**

Users continue to specify "Dedicated" or "AzureDiagnostics" as input values
The module now automatically translates "Dedicated" to null internally to match Azure's behavior

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
