### PR TITLE
fix: add sensitive = true to scope_maps and token password outputs

### DIFF
--- a/modules/scope-map/outputs.tf
+++ b/modules/scope-map/outputs.tf
@@ -5,6 +5,7 @@ output "id" {
 
 output "registry_token_passwords" {
   description = "The registry token password object."
+  sensitive   = true
   value       = azurerm_container_registry_token_password.this
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,7 @@ The scope map module contains the following outputs:
     - `password1` - The first password object of the token.
     - `password2` - The second password object of the token.
 DESCRIPTION
+  sensitive   = true
   value       = module.scope_maps
 }
 


### PR DESCRIPTION
## Summary

Mark `output "scope_maps"` in the root module and `output "registry_token_passwords"` in the scope-map submodule as `sensitive = true` to prevent token passwords from being displayed in plain text.

## Changes

- **`outputs.tf`**: Added `sensitive = true` to `output "scope_maps"`
- **`modules/scope-map/outputs.tf`**: Added `sensitive = true` to `output "registry_token_passwords"`

## Context

Without `sensitive = true`, token passwords may be inadvertently exposed in:
- Terraform CLI output (`terraform apply`, `terraform output`)
- CI/CD logs
- State file references when consumed by other modules

Note: The AzureRM Provider already marks password values as `Sensitive: true` at the schema level, so Terraform 1.0+ will track sensitivity automatically. However, explicitly marking module outputs as sensitive is a best practice that provides defense-in-depth.

The example code in `examples/registry-token/outputs.tf` already correctly uses `sensitive = true`.

Fixes #163