### PR TITLE
docs: fix customer_managed_key variable description mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ Default: `false`
 
 ### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
 
-Description: A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.  
-Controls the Customer managed key configuration on this resource. The following properties can be specified:
+Description: Controls the Customer managed key configuration on this resource. The following properties can be specified:
 - `key_vault_resource_id` - (Required) Resource ID of the Key Vault that the customer managed key belongs to.
 - `key_name` - (Required) Specifies the name of the Customer Managed Key Vault Key.
 - `key_version` - (Optional) The version of the Customer Managed Key Vault Key.

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,6 @@ variable "customer_managed_key" {
   })
   default     = null
   description = <<DESCRIPTION
-A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 Controls the Customer managed key configuration on this resource. The following properties can be specified:
 - `key_vault_resource_id` - (Required) Resource ID of the Key Vault that the customer managed key belongs to.
 - `key_name` - (Required) Specifies the name of the Customer Managed Key Vault Key.


### PR DESCRIPTION
## Description

Fixes #144

The `customer_managed_key` variable description in `variables.tf` began with an erroneous sentence that was copy-pasted from the `diagnostic_settings` variable:

> A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.

This line has been removed so the description correctly starts with:

> Controls the Customer managed key configuration on this resource. The following properties can be specified:

## Changes

- Removed the incorrect first line from the `customer_managed_key` description in `variables.tf`
- Regenerated the corresponding entry in `README.md` to match

This is a documentation-only, low-risk change.