### PR TITLE
feat: add private endpoint lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The full `resource` output has been removed because the provider resource object
 
 The admin username and password outputs are sensitive and are only populated when the registry admin account is enabled. Azure recommends using an individual identity, managed identity, service principal, or repository-scoped token instead of sharing the admin account. For more information, see [Authenticate with an Azure container registry](https://learn.microsoft.com/azure/container-registry/container-registry-authentication).
 
+## Resource locks and private endpoints
+
+Private endpoints inherit the Container Registry lock by default. Set `private_endpoints_inherit_lock` to `false` to disable inheritance. A lock configured directly on a `private_endpoints` entry takes precedence over an inherited lock.
+
+`CanNotDelete` prevents deletion while allowing updates. `ReadOnly` also prevents updates and can block changes to private endpoint properties, application security group associations, or private DNS zone groups. With externally managed DNS zone groups, apply the lock only after the external controller or Azure Policy has finished configuring the private endpoint.
+
+Terraform removes module-managed locks before destroying their protected resources. Azure lock removal is eventually consistent, so a destroy can fail temporarily with `ScopeLocked`; retry the operation after the lock removal has propagated.
+
 ## Migrating to `AbacRepositoryPermissions`
 
 Both authorization modes remain supported. When switching an existing registry to `AbacRepositoryPermissions`, stage the change to avoid interrupting access:
@@ -55,6 +63,7 @@ The following requirements are needed by this module:
 The following resources are used by this module:
 
 - [azurerm_container_registry.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) (resource)
+- [azurerm_management_lock.private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
@@ -369,6 +378,14 @@ map(object({
 ```
 
 Default: `{}`
+
+### <a name="input_private_endpoints_inherit_lock"></a> [private\_endpoints\_inherit\_lock](#input\_private\_endpoints\_inherit\_lock)
+
+Description: Whether private endpoints inherit the lock applied to the Container Registry. An explicitly configured private endpoint lock takes precedence.
+
+Type: `bool`
+
+Default: `true`
 
 ### <a name="input_private_endpoints_manage_dns_zone_group"></a> [private\_endpoints\_manage\_dns\_zone\_group](#input\_private\_endpoints\_manage\_dns\_zone\_group)
 

--- a/_header.md
+++ b/_header.md
@@ -24,6 +24,14 @@ The full `resource` output has been removed because the provider resource object
 
 The admin username and password outputs are sensitive and are only populated when the registry admin account is enabled. Azure recommends using an individual identity, managed identity, service principal, or repository-scoped token instead of sharing the admin account. For more information, see [Authenticate with an Azure container registry](https://learn.microsoft.com/azure/container-registry/container-registry-authentication).
 
+## Resource locks and private endpoints
+
+Private endpoints inherit the Container Registry lock by default. Set `private_endpoints_inherit_lock` to `false` to disable inheritance. A lock configured directly on a `private_endpoints` entry takes precedence over an inherited lock.
+
+`CanNotDelete` prevents deletion while allowing updates. `ReadOnly` also prevents updates and can block changes to private endpoint properties, application security group associations, or private DNS zone groups. With externally managed DNS zone groups, apply the lock only after the external controller or Azure Policy has finished configuring the private endpoint.
+
+Terraform removes module-managed locks before destroying their protected resources. Azure lock removal is eventually consistent, so a destroy can fail temporarily with `ScopeLocked`; retry the operation after the lock removal has propagated.
+
 ## Migrating to `AbacRepositoryPermissions`
 
 Both authorization modes remain supported. When switching an existing registry to `AbacRepositoryPermissions`, stage the change to avoid interrupting access:

--- a/examples/private-endpoint/README.md
+++ b/examples/private-endpoint/README.md
@@ -65,6 +65,9 @@ module "containerregistry" {
   # source             = "Azure/avm-containerregistry-registry/azurerm"
   name                = module.naming.container_registry.name_unique
   resource_group_name = azurerm_resource_group.this.name
+  lock = {
+    kind = "CanNotDelete"
+  }
   private_endpoints = {
     primary = {
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]

--- a/examples/private-endpoint/main.tf
+++ b/examples/private-endpoint/main.tf
@@ -58,6 +58,9 @@ module "containerregistry" {
   # source             = "Azure/avm-containerregistry-registry/azurerm"
   name                = module.naming.container_registry.name_unique
   resource_group_name = azurerm_resource_group.this.name
+  lock = {
+    kind = "CanNotDelete"
+  }
   private_endpoints = {
     primary = {
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]

--- a/locals.tf
+++ b/locals.tf
@@ -29,5 +29,9 @@ locals {
       }
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
+  private_endpoint_locks = {
+    for pe_key, pe_value in var.private_endpoints : pe_key => pe_value.lock != null ? pe_value.lock : var.lock
+    if pe_value.lock != null || (var.private_endpoints_inherit_lock && var.lock != null)
+  }
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -75,5 +75,18 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
   for_each = local.private_endpoint_application_security_group_associations
 
   application_security_group_id = each.value.asg_resource_id
-  private_endpoint_id           = azurerm_private_endpoint.this[each.value.pe_key].id
+  private_endpoint_id           = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this[each.value.pe_key].id : azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.value.pe_key].id
+}
+
+resource "azurerm_management_lock" "private_endpoint" {
+  for_each = local.private_endpoint_locks
+
+  lock_level = each.value.kind
+  name       = coalesce(each.value.name, "lock-${each.value.kind}")
+  scope      = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this[each.key].id : azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.key].id
+  notes      = each.value.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+
+  depends_on = [
+    azurerm_private_endpoint_application_security_group_association.this
+  ]
 }

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -1,0 +1,173 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {
+  mock_resource "azurerm_container_registry" {
+    defaults = {
+      id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ContainerRegistry/registries/acrtest"
+      name = "acrtest"
+    }
+  }
+
+  mock_resource "azurerm_private_endpoint" {
+    defaults = {
+      id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/privateEndpoints/pe-acrtest"
+      name = "pe-acrtest"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  enable_telemetry    = false
+  location            = "eastus"
+  name                = "acrtest"
+  resource_group_name = "rg-test"
+}
+
+run "explicit_private_endpoint_lock" {
+  command   = apply
+  state_key = "explicit-private-endpoint-lock"
+
+  variables {
+    private_endpoints = {
+      primary = {
+        lock = {
+          kind = "CanNotDelete"
+          name = "lock-explicit"
+        }
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.private_endpoint) == 1
+    error_message = "An explicitly configured private endpoint lock should be created."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].lock_level == "CanNotDelete"
+    error_message = "The private endpoint lock should use the explicitly configured lock level."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].name == "lock-explicit"
+    error_message = "The private endpoint lock should use the explicitly configured name."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].scope == azurerm_private_endpoint.this["primary"].id
+    error_message = "The lock should target the private endpoint with a module-managed DNS zone group."
+  }
+}
+
+run "inherited_private_endpoint_lock_with_unmanaged_dns" {
+  command   = apply
+  state_key = "inherited-private-endpoint-lock-with-unmanaged-dns"
+
+  variables {
+    lock = {
+      kind = "ReadOnly"
+    }
+    private_endpoints = {
+      primary = {
+        application_security_group_associations = {
+          primary = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
+        }
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+      }
+    }
+    private_endpoints_manage_dns_zone_group = false
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.private_endpoint) == 1
+    error_message = "The Container Registry lock should be inherited by its private endpoint."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].lock_level == "ReadOnly"
+    error_message = "The private endpoint should inherit the Container Registry lock level."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].name == "lock-ReadOnly"
+    error_message = "An inherited private endpoint lock should have a default name based on its kind."
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].scope == azurerm_private_endpoint.this_unmanaged_dns_zone_groups["primary"].id
+    error_message = "The lock should target the private endpoint whose DNS zone group is managed externally."
+  }
+
+  assert {
+    condition     = azurerm_private_endpoint_application_security_group_association.this["primary-primary"].private_endpoint_id == azurerm_private_endpoint.this_unmanaged_dns_zone_groups["primary"].id
+    error_message = "The application security group association should target the private endpoint whose DNS zone group is managed externally."
+  }
+}
+
+run "explicit_lock_overrides_inherited_lock" {
+  command   = apply
+  state_key = "explicit-lock-overrides-inherited-lock"
+
+  variables {
+    lock = {
+      kind = "ReadOnly"
+    }
+    private_endpoints = {
+      primary = {
+        lock = {
+          kind = "CanNotDelete"
+        }
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+      }
+    }
+  }
+
+  assert {
+    condition     = azurerm_management_lock.private_endpoint["primary"].lock_level == "CanNotDelete"
+    error_message = "An explicit private endpoint lock should take precedence over the inherited Container Registry lock."
+  }
+}
+
+run "private_endpoint_lock_inheritance_disabled" {
+  command   = apply
+  state_key = "private-endpoint-lock-inheritance-disabled"
+
+  variables {
+    lock = {
+      kind = "CanNotDelete"
+    }
+    private_endpoints = {
+      primary = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+      }
+    }
+    private_endpoints_inherit_lock = false
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.private_endpoint) == 0
+    error_message = "A private endpoint lock should not be created when inheritance is disabled."
+  }
+}
+
+run "invalid_private_endpoint_lock_kind" {
+  command   = plan
+  state_key = "invalid-private-endpoint-lock-kind"
+
+  variables {
+    private_endpoints = {
+      primary = {
+        lock = {
+          kind = "Invalid"
+        }
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+      }
+    }
+  }
+
+  expect_failures = [
+    var.private_endpoints,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -198,6 +198,21 @@ A map of private endpoints to create on the Container Registry. The map key is d
   - `private_ip_address` - The private IP address of the IP configuration.
 DESCRIPTION
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for private_endpoint in var.private_endpoints :
+      private_endpoint.lock == null ? true : contains(["CanNotDelete", "ReadOnly"], private_endpoint.lock.kind)
+    ])
+    error_message = "Each private endpoint lock kind must be either `\"CanNotDelete\"` or `\"ReadOnly\"`."
+  }
+}
+
+variable "private_endpoints_inherit_lock" {
+  type        = bool
+  default     = true
+  description = "Whether private endpoints inherit the lock applied to the Container Registry. An explicitly configured private endpoint lock takes precedence."
+  nullable    = false
 }
 
 variable "private_endpoints_manage_dns_zone_group" {


### PR DESCRIPTION
## Summary

- create management locks for explicitly configured private endpoint locks
- inherit the Container Registry lock by default, with `private_endpoints_inherit_lock` as an opt-out
- support both module-managed and externally managed private DNS zone groups
- ensure explicit private endpoint locks override inherited locks
- correct ASG association targeting for externally managed DNS zone groups
- add validation, unit coverage, an E2E example, and generated documentation

## Validation

- `avm pre-commit`
- `avm tf-test-unit` (5 passed)
- Local `avm pr-check` reached example planning; one provider download hit a transient TLS timeout and the remaining Well-Architected plans were blocked by a stale local Azure CLI login. CI will run these plans with authenticated credentials.

## Release impact

This should be released as a minor version because existing consumers with a Container Registry lock and private endpoints will begin receiving inherited private endpoint locks by default.

Closes #129