### PR TITLE
docs: correct spelling in anonymous_pull_enabled description

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Default: `false`
 
 ### <a name="input_anonymous_pull_enabled"></a> [anonymous\_pull\_enabled](#input\_anonymous\_pull\_enabled)
 
-Description: Specifies whether anonymous (unauthenticated) pull access to this Container Registry is allowed.  Requries Standard or Premium SKU.
+Description: Specifies whether anonymous (unauthenticated) pull access to this Container Registry is allowed.  Requires Standard or Premium SKU.
 
 Type: `bool`
 

--- a/variables.containerregistry.tf
+++ b/variables.containerregistry.tf
@@ -7,7 +7,7 @@ variable "admin_enabled" {
 variable "anonymous_pull_enabled" {
   type        = bool
   default     = false
-  description = "Specifies whether anonymous (unauthenticated) pull access to this Container Registry is allowed.  Requries Standard or Premium SKU."
+  description = "Specifies whether anonymous (unauthenticated) pull access to this Container Registry is allowed.  Requires Standard or Premium SKU."
 }
 
 variable "data_endpoint_enabled" {


### PR DESCRIPTION
Release branch for #207 by @vladdoster.

Fixes `Requries` -> `Requires` in the `anonymous_pull_enabled` description. Adds the source fix in `variables.containerregistry.tf`, since `README.md` is generated by terraform-docs and would otherwise regenerate the typo.

Closes #207