### PR TITLE
fix: replace deprecated diagnostic metric block

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Description: A map of private endpoints to create on the Container Registry. The
   - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+- `subresource_name` - (Optional) The private endpoint subresource used by the service connection and IP configurations. Defaults to `registry` when omitted or null. The IP configuration member name remains `registry`.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
 - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
 - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -421,6 +422,7 @@ map(object({
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -13,7 +13,7 @@ resource "azurerm_private_endpoint" "this" {
     is_manual_connection           = false
     name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
     private_connection_resource_id = azurerm_container_registry.this.id
-    subresource_names              = ["registry"]
+    subresource_names              = [coalesce(each.value.subresource_name, "registry")]
   }
 
   dynamic "ip_configuration" {
@@ -23,7 +23,7 @@ resource "azurerm_private_endpoint" "this" {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
       member_name        = "registry"
-      subresource_name   = "registry"
+      subresource_name   = coalesce(each.value.subresource_name, "registry")
     }
   }
 
@@ -52,7 +52,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
     is_manual_connection           = false
     name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
     private_connection_resource_id = azurerm_container_registry.this.id
-    subresource_names              = ["registry"]
+    subresource_names              = [coalesce(each.value.subresource_name, "registry")]
   }
 
   dynamic "ip_configuration" {
@@ -62,7 +62,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
       member_name        = "registry"
-      subresource_name   = "registry"
+      subresource_name   = coalesce(each.value.subresource_name, "registry")
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -146,11 +146,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }

--- a/modules/scope-map/README.md
+++ b/modules/scope-map/README.md
@@ -11,8 +11,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4, < 5.0.0)
 
 ## Resources

--- a/modules/scope-map/terraform.tf
+++ b/modules/scope-map/terraform.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.12"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 4, < 5.0.0"

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -24,6 +24,64 @@ variables {
   resource_group_name = "rg-test"
 }
 
+run "diagnostic_settings_disabled_by_default" {
+  command   = plan
+  state_key = "diagnostic-settings-disabled-by-default"
+
+  assert {
+    condition     = length(azurerm_monitor_diagnostic_setting.this) == 0
+    error_message = "Diagnostic settings should not be created unless configured."
+  }
+}
+
+run "diagnostic_settings_default_metrics" {
+  command   = plan
+  state_key = "diagnostic-settings-default-metrics"
+
+  variables {
+    diagnostic_settings = {
+      primary = {
+        workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.OperationalInsights/workspaces/law-test"
+      }
+    }
+  }
+
+  assert {
+    condition     = toset([for metric in azurerm_monitor_diagnostic_setting.this["primary"].enabled_metric : metric.category]) == toset(["AllMetrics"])
+    error_message = "Diagnostic settings should configure AllMetrics through enabled_metric by default."
+  }
+
+  assert {
+    condition     = toset([for log in azurerm_monitor_diagnostic_setting.this["primary"].enabled_log : log.category_group]) == toset(["allLogs"])
+    error_message = "Diagnostic settings should continue to enable the allLogs category group by default."
+  }
+}
+
+run "diagnostic_settings_metrics_only" {
+  command   = plan
+  state_key = "diagnostic-settings-metrics-only"
+
+  variables {
+    diagnostic_settings = {
+      primary = {
+        log_groups            = []
+        metric_categories     = ["AllMetrics"]
+        workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.OperationalInsights/workspaces/law-test"
+      }
+    }
+  }
+
+  assert {
+    condition     = toset([for metric in azurerm_monitor_diagnostic_setting.this["primary"].enabled_metric : metric.category]) == toset(["AllMetrics"])
+    error_message = "Explicit metric categories should be configured through enabled_metric without requiring logs."
+  }
+
+  assert {
+    condition     = length(azurerm_monitor_diagnostic_setting.this["primary"].enabled_log) == 0
+    error_message = "A metrics-only diagnostic setting should not enable any logs."
+  }
+}
+
 run "explicit_private_endpoint_lock" {
   command   = apply
   state_key = "explicit-private-endpoint-lock"

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -229,3 +229,129 @@ run "invalid_private_endpoint_lock_kind" {
     var.private_endpoints,
   ]
 }
+
+run "private_endpoint_subresource_with_managed_dns" {
+  command   = apply
+  state_key = "private-endpoint-subresource-with-managed-dns"
+
+  variables {
+    private_endpoints = {
+      omitted = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.4"
+          }
+        }
+      }
+      null_value = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = null
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.5"
+          }
+        }
+      }
+      explicit = {
+        private_dns_zone_resource_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"]
+        subnet_resource_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        # A distinct mock-only value proves that the input is not replaced by the registry default.
+        subresource_name = "custom-subresource"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.6"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for key, endpoint in azurerm_private_endpoint.this :
+      endpoint.private_service_connection[0].subresource_names == tolist([key == "explicit" ? "custom-subresource" : "registry"]) &&
+      endpoint.ip_configuration[0].subresource_name == (key == "explicit" ? "custom-subresource" : "registry") &&
+      endpoint.ip_configuration[0].member_name == "registry"
+    ])
+    error_message = "Managed DNS endpoints must honor explicit subresources in connections and IP configurations, default omitted/null values to registry, and retain the registry member name."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 3 && length(azurerm_private_endpoint.this_unmanaged_dns_zone_groups) == 0
+    error_message = "Managed DNS must create only the three module-managed private endpoints."
+  }
+
+  assert {
+    condition     = azurerm_private_endpoint.this["explicit"].private_dns_zone_group[0].name == "default"
+    error_message = "The default DNS zone group name must remain unchanged."
+  }
+
+  assert {
+    condition     = output.private_endpoints == tomap(azurerm_private_endpoint.this)
+    error_message = "The private endpoints output must continue exposing the module-managed endpoint resources."
+  }
+}
+
+run "private_endpoint_subresource_with_unmanaged_dns" {
+  command   = apply
+  state_key = "private-endpoint-subresource-with-unmanaged-dns"
+
+  variables {
+    private_endpoints = {
+      omitted = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.4"
+          }
+        }
+      }
+      null_value = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = null
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.5"
+          }
+        }
+      }
+      explicit = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = "custom-subresource"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.6"
+          }
+        }
+      }
+    }
+    private_endpoints_manage_dns_zone_group = false
+  }
+
+  assert {
+    condition = alltrue([
+      for key, endpoint in azurerm_private_endpoint.this_unmanaged_dns_zone_groups :
+      endpoint.private_service_connection[0].subresource_names == tolist([key == "explicit" ? "custom-subresource" : "registry"]) &&
+      endpoint.ip_configuration[0].subresource_name == (key == "explicit" ? "custom-subresource" : "registry") &&
+      endpoint.ip_configuration[0].member_name == "registry"
+    ])
+    error_message = "Unmanaged DNS endpoints must honor explicit subresources in connections and IP configurations, default omitted/null values to registry, and retain the registry member name."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this_unmanaged_dns_zone_groups) == 3 && length(azurerm_private_endpoint.this) == 0
+    error_message = "Unmanaged DNS must create only the three externally managed DNS private endpoints."
+  }
+
+  assert {
+    condition     = output.private_endpoints == tomap(azurerm_private_endpoint.this_unmanaged_dns_zone_groups)
+    error_message = "The private endpoints output must continue exposing the externally managed DNS endpoint resources."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,7 @@ variable "private_endpoints" {
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})
@@ -186,6 +187,7 @@ A map of private endpoints to create on the Container Registry. The map key is d
   - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+- `subresource_name` - (Optional) The private endpoint subresource used by the service connection and IP configurations. Defaults to `registry` when omitted or null. The IP configuration member name remains `registry`.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
 - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
 - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.


### PR DESCRIPTION
## Description

Closes #211.

Replace the diagnostic setting's deprecated `metric` block with `enabled_metric` and update its iterator reference. This removes the AzureRM deprecation warning while preserving the caller-facing `diagnostic_settings` input, the `AllMetrics` default, and existing resource addresses.

The existing AzureRM minimum (`4.81.0`) already supports `enabled_metric`. Provider version constraints remain unchanged. This is warning cleanup, not an AzureRM v5 upgrade or an AzAPI migration.

## Included CI fixes

Child PR #217 has been merged into this branch. It resolves two pre-existing lint blockers:

- Add and wire optional `private_endpoints[*].subresource_name` for connections and IP configurations in both DNS ownership paths. Omitted or null values retain the `registry` default; IP member names remain unchanged.
- Remove the unused AzAPI provider requirement from the `scope-map` submodule. This warning also blocked the managed lint gate.

No resources, dependencies, or lint suppressions are added. Broader private-endpoint interface migration and the existing unimplemented nested role assignments remain outside this change. Related READMEs were regenerated.

## Validation

The [latest CI run](https://github.com/Azure/terraform-azurerm-avm-res-containerregistry-registry/actions/runs/34527056788) passes after incorporating #217: full Linux PR gate, unit tests, and all nine example deployments. CodeQL and CLA checks also pass.

Mocked coverage includes diagnostic defaults, metrics-only settings, and omitted, null, and explicit private-endpoint subresource values across both DNS ownership paths.

Local pre-commit passed. Local PR-check execution is unavailable on Windows ARM64 because TFLint has no matching release; Linux CI covers the full gate. No live Azure deployments ran locally.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->