### PR TITLE
fix: expose private endpoint subresource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Description: A map of private endpoints to create on the Container Registry. The
   - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+- `subresource_name` - (Optional) The private endpoint subresource used by the service connection and IP configurations. Defaults to `registry` when omitted or null. The IP configuration member name remains `registry`.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
 - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
 - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -421,6 +422,7 @@ map(object({
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -13,7 +13,7 @@ resource "azurerm_private_endpoint" "this" {
     is_manual_connection           = false
     name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
     private_connection_resource_id = azurerm_container_registry.this.id
-    subresource_names              = ["registry"]
+    subresource_names              = [coalesce(each.value.subresource_name, "registry")]
   }
 
   dynamic "ip_configuration" {
@@ -23,7 +23,7 @@ resource "azurerm_private_endpoint" "this" {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
       member_name        = "registry"
-      subresource_name   = "registry"
+      subresource_name   = coalesce(each.value.subresource_name, "registry")
     }
   }
 
@@ -52,7 +52,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
     is_manual_connection           = false
     name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
     private_connection_resource_id = azurerm_container_registry.this.id
-    subresource_names              = ["registry"]
+    subresource_names              = [coalesce(each.value.subresource_name, "registry")]
   }
 
   dynamic "ip_configuration" {
@@ -62,7 +62,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
       member_name        = "registry"
-      subresource_name   = "registry"
+      subresource_name   = coalesce(each.value.subresource_name, "registry")
     }
   }
 

--- a/modules/scope-map/README.md
+++ b/modules/scope-map/README.md
@@ -11,8 +11,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4, < 5.0.0)
 
 ## Resources

--- a/modules/scope-map/terraform.tf
+++ b/modules/scope-map/terraform.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.12"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 4, < 5.0.0"

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -229,3 +229,129 @@ run "invalid_private_endpoint_lock_kind" {
     var.private_endpoints,
   ]
 }
+
+run "private_endpoint_subresource_with_managed_dns" {
+  command   = apply
+  state_key = "private-endpoint-subresource-with-managed-dns"
+
+  variables {
+    private_endpoints = {
+      omitted = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.4"
+          }
+        }
+      }
+      null_value = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = null
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.5"
+          }
+        }
+      }
+      explicit = {
+        private_dns_zone_resource_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/privateDnsZones/privatelink.azurecr.io"]
+        subnet_resource_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        # A distinct mock-only value proves that the input is not replaced by the registry default.
+        subresource_name = "custom-subresource"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.6"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for key, endpoint in azurerm_private_endpoint.this :
+      endpoint.private_service_connection[0].subresource_names == tolist([key == "explicit" ? "custom-subresource" : "registry"]) &&
+      endpoint.ip_configuration[0].subresource_name == (key == "explicit" ? "custom-subresource" : "registry") &&
+      endpoint.ip_configuration[0].member_name == "registry"
+    ])
+    error_message = "Managed DNS endpoints must honor explicit subresources in connections and IP configurations, default omitted/null values to registry, and retain the registry member name."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 3 && length(azurerm_private_endpoint.this_unmanaged_dns_zone_groups) == 0
+    error_message = "Managed DNS must create only the three module-managed private endpoints."
+  }
+
+  assert {
+    condition     = azurerm_private_endpoint.this["explicit"].private_dns_zone_group[0].name == "default"
+    error_message = "The default DNS zone group name must remain unchanged."
+  }
+
+  assert {
+    condition     = output.private_endpoints == tomap(azurerm_private_endpoint.this)
+    error_message = "The private endpoints output must continue exposing the module-managed endpoint resources."
+  }
+}
+
+run "private_endpoint_subresource_with_unmanaged_dns" {
+  command   = apply
+  state_key = "private-endpoint-subresource-with-unmanaged-dns"
+
+  variables {
+    private_endpoints = {
+      omitted = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.4"
+          }
+        }
+      }
+      null_value = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = null
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.5"
+          }
+        }
+      }
+      explicit = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        subresource_name   = "custom-subresource"
+        ip_configurations = {
+          primary = {
+            name               = "primary"
+            private_ip_address = "10.0.0.6"
+          }
+        }
+      }
+    }
+    private_endpoints_manage_dns_zone_group = false
+  }
+
+  assert {
+    condition = alltrue([
+      for key, endpoint in azurerm_private_endpoint.this_unmanaged_dns_zone_groups :
+      endpoint.private_service_connection[0].subresource_names == tolist([key == "explicit" ? "custom-subresource" : "registry"]) &&
+      endpoint.ip_configuration[0].subresource_name == (key == "explicit" ? "custom-subresource" : "registry") &&
+      endpoint.ip_configuration[0].member_name == "registry"
+    ])
+    error_message = "Unmanaged DNS endpoints must honor explicit subresources in connections and IP configurations, default omitted/null values to registry, and retain the registry member name."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this_unmanaged_dns_zone_groups) == 3 && length(azurerm_private_endpoint.this) == 0
+    error_message = "Unmanaged DNS must create only the three externally managed DNS private endpoints."
+  }
+
+  assert {
+    condition     = output.private_endpoints == tomap(azurerm_private_endpoint.this_unmanaged_dns_zone_groups)
+    error_message = "The private endpoints output must continue exposing the externally managed DNS endpoint resources."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,7 @@ variable "private_endpoints" {
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})
@@ -186,6 +187,7 @@ A map of private endpoints to create on the Container Registry. The map key is d
   - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+- `subresource_name` - (Optional) The private endpoint subresource used by the service connection and IP configurations. Defaults to `registry` when omitted or null. The IP configuration member name remains `registry`.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
 - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
 - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.


### PR DESCRIPTION
## Description

Fix two pre-existing lint failures blocking #216. This child PR has been merged into #216's branch, `deprecated-metric-block`, rather than directly into `main`. The diagnostic metric fix remains unchanged.

## Changes

- Add optional `private_endpoints[*].subresource_name` and forward it to the private service connection and IP configurations in both DNS ownership paths. Omitted or null values retain the existing `registry` default. IP member names remain `registry`.
- Remove the unused AzAPI provider requirement from the `scope-map` submodule and regenerate its README. The unused-provider warning blocks the managed lint gate, even though it is labeled a warning.

## Compatibility

Existing resource addresses, outputs, lock behavior, and used-provider constraints remain unchanged. No resources, dependencies, or lint suppressions are added.

The [released AVM ruleset](https://github.com/Azure/tflint-ruleset-avm/blob/v1.0.0/interfaces/avm_interface_private_endpoints.go) accepts this transitional private-endpoint interface. Only `subresource_name` was required to resolve the fatal schema mismatch. Broader interface migration and the existing unimplemented nested role assignments remain outside this change.

Removing the unused provider follows [TFNFR26](https://azure.github.io/Azure-Verified-Modules/spec/TFNFR26/); the managed transform does not restore it.

## Validation

[Final CI run](https://github.com/Azure/terraform-azurerm-avm-res-containerregistry-registry/actions/runs/34525476046) passed the full Linux PR gate, including lint, all 18 mocked unit runs, and all nine example deployments.

Two new unit runs cover omitted, null, and explicit subresource values across both DNS ownership paths. Integration execution was skipped because no integration tests exist.

Local pre-commit passed. The local PR gate is unavailable on Windows ARM64 because TFLint has no matching release; Linux CI provides that coverage. No live Azure deployments ran locally.